### PR TITLE
add allowlist entry for miui usb debugging (security settings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ This [request](https://oisd.nl/excludes.php?w=settings-win.data.microsoft.com) i
 
 	update.intl.miui.com
 
+### Xiaomi USB debugging (Security settings)
+
+	srv.sec.intl.miui.com
+
 ### Google Nest usage metrics <sup><sup>[1](https://www.reddit.com/r/nextdns/comments/yzvnuw/nest_usage_metrics_being_blocked)</sup></sup> 
 
 	logsink.devices.nest.com


### PR DESCRIPTION
This is a very very niche use case

Xiaomi devices running MIUI have a developer setting
![usb_debug_sec](https://github.com/yokoffing/NextDNS-Config/assets/87397831/497af24e-d56d-4bf2-8b25-6b273ff9344e)
which cannot be enabled when using hagezi(multi-ultimate) and 1hosts(pro) [probably even more, haven't tested others]
![nextdns_log](https://github.com/yokoffing/NextDNS-Config/assets/87397831/25440281-e548-4324-a59a-cd158add8e7c)
