### PR TITLE
Add information about allowlisting Paramount+

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,29 @@ This [request](https://oisd.nl/excludes.php?w=settings-win.data.microsoft.com) i
 	pubads.g.doubleclick.net
 	tags.tiqcdn.com 
 
+### [Paramount+](https://www.paramountplus.com/)
+
+These domains are used by Paramount+ to display ads. Even if you have an ad-free plan, these domains must be
+resolvable to view Paramount+ content. They are in most blocklists, so will need to be added to your allowlist. 
+Unfortunately they are widely used, so unblocking them will likely decrease the number of ads blocked elsewhere.
+
+        imasdk.googleapis.com
+        pubads.g.doubleclick.net
+
+It [has been reported](https://www.reddit.com/r/nextdns/comments/v84ag6/paramount_plus/) that you might need to
+unblock the following, if any of them are in a blocklist you're using.
+
+        cbsaavideo.com
+        cbsi.com
+	conviva.com
+        convivia.com
+	demdex.net
+        dns-clientinfo.cbsivideo.com
+	partnerad.l.doubleclick.net
+        saa.cbsi.com
+	summerhamster.com (yes, really)
+        udm.scorecardresearch.com
+
 ### [FiveThirtyEight](https://fivethirtyeight.com) videos / [National Geographic](https://nationalgeographic.com) website <sup><sup>[1](https://github.com/notracking/hosts-blocklists/issues/788)</sup></sup>
 
 	dcf.espn.com

--- a/README.md
+++ b/README.md
@@ -321,22 +321,22 @@ These domains are used by Paramount+ to display ads. Even if you have an ad-free
 resolvable to view Paramount+ content. They are in most blocklists, so will need to be added to your allowlist. 
 Unfortunately they are widely used, so unblocking them will likely decrease the number of ads blocked elsewhere.
 
-        imasdk.googleapis.com
-        pubads.g.doubleclick.net
+    imasdk.googleapis.com
+    pubads.g.doubleclick.net
 
 It [has been reported](https://www.reddit.com/r/nextdns/comments/v84ag6/paramount_plus/) that you might need to
 unblock the following, if any of them are in a blocklist you're using.
 
-        cbsaavideo.com
-        cbsi.com
-	conviva.com
-        convivia.com
-	demdex.net
-        dns-clientinfo.cbsivideo.com
-	partnerad.l.doubleclick.net
-        saa.cbsi.com
-	summerhamster.com (yes, really)
-        udm.scorecardresearch.com
+    cbsaavideo.com
+    cbsi.com
+    conviva.com
+    convivia.com
+    demdex.net
+    dns-clientinfo.cbsivideo.com
+    partnerad.l.doubleclick.net
+    saa.cbsi.com
+    summerhamster.com (yes, really)
+    udm.scorecardresearch.com
 
 ### [FiveThirtyEight](https://fivethirtyeight.com) videos / [National Geographic](https://nationalgeographic.com) website <sup><sup>[1](https://github.com/notracking/hosts-blocklists/issues/788)</sup></sup>
 

--- a/README.md
+++ b/README.md
@@ -317,15 +317,14 @@ This [request](https://oisd.nl/excludes.php?w=settings-win.data.microsoft.com) i
 
 ### [Paramount+](https://www.paramountplus.com/)
 
-These domains are used by Paramount+ to display ads. Even if you have an ad-free plan, these domains must be
-resolvable to view Paramount+ content. They are in most blocklists, so will need to be added to your allowlist. 
-Unfortunately they are widely used, so unblocking them will likely decrease the number of ads blocked elsewhere.
+Paramount+ uses certain domains to display ads. These domains must be accessible to allow Paramount+ content to load (even for viewers with ad-free plans).
+
+:warning: However, because many sites use these domains for ads, allowing them could result in more ads being shown on other sites you visit.
 
     imasdk.googleapis.com
     pubads.g.doubleclick.net
 
-It [has been reported](https://www.reddit.com/r/nextdns/comments/v84ag6/paramount_plus/) that you might need to
-unblock the following, if any of them are in a blocklist you're using.
+Users have [reported](https://www.reddit.com/r/nextdns/comments/v84ag6/paramount_plus/) that the following domains also may need to be allowed:
 
     cbsaavideo.com
     cbsi.com

--- a/README.md
+++ b/README.md
@@ -345,15 +345,6 @@ Users have [reported](https://www.reddit.com/r/nextdns/comments/v84ag6/paramount
 
 	glimmer.hearstapps.com
 
-### [Ghostery](https://ghostery.com/ghostery-ad-blocker) Analytics (opt-in)
-
-User data is [removed](https://0x65.dev/blog/2019-12-04/human-web-proxy-network-hpn.html). Contributes to the [Human Web](https://0x65.dev/blog/2019-12-03/human-web-collecting-data-in-a-socially-responsible-manner.html) and [WhoTracks.me](https://whotracks.me) data
-
-	collector-hpn.ghostery.net
-	collector-hpn.privacy.ghostery.net
-	d.ghostery.com
-
-
 </details>
 
 ***


### PR DESCRIPTION
This is information I gleaned from various sources about getting Paramount+ to work with common blocklists. The two domains I listed first were the only ones I needed to unblock on my network, but I added the others I came across for completeness.